### PR TITLE
Fixes: decode and remove reduntant line

### DIFF
--- a/layer.go
+++ b/layer.go
@@ -33,7 +33,6 @@ func (l GUE) LayerContents() []byte {
 	if l.C {
 		b[0] |= 0x20
 	}
-	b[0] |= hlen
 	b[1] = byte(l.Protocol)
 	b[2] = byte(l.Flags >> 8)
 	b[3] = byte(l.Flags & 0xff)
@@ -75,7 +74,7 @@ func (l GUE) NextLayerType() gopacket.LayerType {
 }
 
 func DecodeGUE(data []byte, p gopacket.PacketBuilder) error {
-	l := GUE{}
+	l := &GUE{}
 	if err := l.DecodeFromBytes(data, gopacket.NilDecodeFeedback); err != nil {
 		return err
 	}

--- a/layer_test.go
+++ b/layer_test.go
@@ -38,7 +38,7 @@ func TestDecoding(t *testing.T) {
 	require.Nil(t, p.ErrorLayer())
 	t.Logf("%v", p)
 
-	gue := p.Layer(GUELayerType).(GUE)
+	gue := p.Layer(GUELayerType).(*GUE)
 	require.NotNil(t, gue)
 	assert.Equal(t, uint8(0), gue.Version)
 }


### PR DESCRIPTION
- Best to use &GUE{} in decoder, to stay consistent with all other mainstream decoders in gopacket
- Removed redundant hlen set on first byte of header
 